### PR TITLE
add pmap/laxmap

### DIFF
--- a/kernex/_src/utils.py
+++ b/kernex/_src/utils.py
@@ -23,8 +23,14 @@ import numpy as np
 from jax import lax
 from jax.util import safe_zip
 
+transform_func_map = {
+    "vmap": jax.vmap,
+    "lmap": lambda func, **k: (lambda xs: jax.lax.map(func, xs, **k)),
+    "pmap": jax.pmap,
+    "scan": jax.lax.scan,
+}
 
-@ft.lru_cache(maxsize=128)
+
 def _calculate_pad_width(border: tuple[tuple[int, int], ...]):
     """Calcuate the positive padding from border value
 
@@ -56,7 +62,6 @@ def _get_index_from_view(
     )
 
 
-@ft.lru_cache(maxsize=128)
 def _generate_views(
     shape: tuple[int, ...],
     kernel_size: tuple[int, ...],


### PR DESCRIPTION
Enable `jax.lax.map`/ `jax.pmap` in the `kmap`/`smap` interface 
Example:
```python

import os

os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=200"

import jax
import jax
import kernex as kex


@kex.kmap(
    kernel_size=(2,),
    map_kind="pmap",
    map_kwargs={"axis_name": "i"},
)
def f(x):
    return x


print(f(jax.numpy.arange(5)))

# [[0 1]
#  [1 2]
#  [2 3]
#  [3 4]]

```


