### PR TITLE
Add padding _kwargs

### DIFF
--- a/kernex/__init__.py
+++ b/kernex/__init__.py
@@ -27,4 +27,4 @@ __all__ = (
     "offset_kernel_scan",
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/kernex/_src/scan.py
+++ b/kernex/_src/scan.py
@@ -71,9 +71,12 @@ def kernel_scan(
     relative: bool = False,
     scan_kind: ScanKind = "scan",  # dummy to make signature consistent with kernel_map
     scan_kwargs: dict[str, Any] | None = None,
+    padding_kwargs: dict[str, Any] | None = None,
 ):
 
     scan_kwargs = scan_kwargs or {}
+    padding_kwargs = padding_kwargs or {}
+    padding_kwargs.pop("pad_width", None)
     scan_transform = transform_func_map[scan_kind]
     pad_width = _calculate_pad_width(border)
     args = (shape, kernel_size, strides, border)
@@ -82,7 +85,7 @@ def kernel_scan(
     slices = tuple(func_map.values())
 
     def single_call_wrapper(array: jax.Array, *a, **k):
-        padded_array = jnp.pad(array, pad_width)
+        padded_array = jnp.pad(array, pad_width=pad_width, **padding_kwargs)
         func0 = next(iter(func_map))
         reduced_func = _transform_scan_func(func0, kernel_size, relative)(*a, **k)
 
@@ -95,7 +98,7 @@ def kernel_scan(
         return result.reshape(output_shape)
 
     def multi_call_wrapper(array: jax.Array, *a, **k):
-        padded_array = jnp.pad(array, pad_width)
+        padded_array = jnp.pad(array, pad_width=pad_width, **padding_kwargs)
 
         reduced_funcs = tuple(
             _transform_scan_func(func, kernel_size, relative)(*a, **k)
@@ -124,6 +127,7 @@ def offset_kernel_scan(
     relative: bool = False,
     scan_kind: ScanKind = "scan",
     scan_kwargs: dict[str, Any] | None = None,
+    offset_kwargs: dict[str, Any] | None = None,
 ):
 
     func = kernel_scan(
@@ -135,6 +139,7 @@ def offset_kernel_scan(
         relative=relative,
         scan_kind=scan_kind,
         scan_kwargs=scan_kwargs,
+        padding_kwargs=offset_kwargs,
     )
     set_indices = _get_set_indices(shape, strides, offset)
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -346,3 +346,21 @@ def test_conv2d(map_kind):
     pred_grad = jax.grad(lambda w: jnp.sum(kex_conv2d(x, w)))(w)
 
     np.testing.assert_allclose(true_grad[0], pred_grad, atol=1e-3)
+
+
+def test_padding_kwargs():
+    @kex.kmap(
+        kernel_size=(3,),
+        padding=("same"),
+        relative=False,
+        padding_kwargs=dict(constant_values=10),
+    )
+    def f(x):
+        return x
+
+    x = jnp.array([1, 2, 3, 4, 5])
+
+    np.testing.assert_allclose(
+        f(x),
+        np.array([[10, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 10]]),
+    )


### PR DESCRIPTION
closes #12 

Example

```python
    @kex.kmap(
        kernel_size=(3,),
        padding=("same"),
        relative=False,
        padding_kwargs=dict(constant_values=10),
    )
    def f(x):
        return x

    x = jnp.array([1, 2, 3, 4, 5])

    np.testing.assert_allclose(
        f(x),
        np.array([[10, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 10]]),
    )

```